### PR TITLE
aegis256.c: fix aarch64 build with uclibc

### DIFF
--- a/aegis256.c
+++ b/aegis256.c
@@ -48,7 +48,7 @@ typedef __m128i       x128;
 #endif
 
 #ifdef __ARM_FEATURE_CRYPTO
-#ifdef __linux__
+#if defined(__linux__) && __has_include("sys/auxv.h")
 #include <sys/auxv.h>
 #endif
 #include <arm_neon.h>
@@ -64,7 +64,7 @@ typedef uint8x16_t    x128;
 int
 aegis256_is_available(void)
 {
-#ifdef __linux__
+#if defined(__linux__) && __has_include("sys/auxv.h")
     return (getauxval(AT_HWCAP) & HWCAP_AES)
 #ifdef HWCAP2_AES
         || (getauxval(AT_HWCAP2) & HWCAP2_AES)


### PR DESCRIPTION
Fix the following aarch64 build failure with uclibc:

```
mud/aegis256/aegis256.c:51:10: fatal error: sys/auxv.h: No such file or directory
   51 | #include <sys/auxv.h>
      |          ^~~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/4e1bbd72b9b7e0f9963f6693c3d7bc9a1d24fab4

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>